### PR TITLE
Reinstall servicecontrol package on new installer download

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,11 +17,12 @@ class nservicebusservicecontrol::install {
   }
 
   package { 'ServiceControl':
-    ensure            => $nservicebusservicecontrol::package_ensure,
-    source            => $nservicebusservicecontrol::remote_file_path,
-    install_options   => ['/Quiet'],
-    uninstall_options => ['/Quiet'],
-    require           => Remote_file[$nservicebusservicecontrol::remote_file_path],
+    ensure               => $nservicebusservicecontrol::package_ensure,
+    source               => $nservicebusservicecontrol::remote_file_path,
+    install_options      => ['/Quiet'],
+    uninstall_options    => ['/Quiet'],
+    reinstall_on_refresh => true,
+    subscribe            => Remote_file[$nservicebusservicecontrol::remote_file_path],
   }
 
 }


### PR DESCRIPTION
This feature addes the ability to reinstall servicecontrol when the remote_file resource downloads a *new version* of service control.  This allows it to act like a real package manager but still needs to be improved to utilize chocolatey in the future for people with more advanced and flexible needs.